### PR TITLE
FSCT-33-Remove-device-polling

### DIFF
--- a/core/src/devices_watch.rs
+++ b/core/src/devices_watch.rs
@@ -43,6 +43,11 @@ impl DevicesWatchHandle {
             shutdown_requested
         }
     }
+    
+    pub fn abort(self)
+    {
+        self.join_handle.abort();
+    }
 
     pub async fn shutdown(self) -> Result<(), tokio::task::JoinError> {
         self.signal_shutdown();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,6 +25,7 @@ mod devices_watch;
 pub use service_entry::run_service;
 pub use player_watch::run_player_watch;
 pub use devices_watch::run_devices_watch;
+pub use devices_watch::DevicesWatchHandle;
 pub use player::Player;
 pub use player_watch::NoopPlayerEventListener;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod player;
 mod player_watch;
 mod service_entry;
 mod devices_watch;
+mod service_state;
 
 pub use service_entry::run_service;
 pub use player_watch::run_player_watch;
@@ -32,3 +33,4 @@ pub use player_watch::NoopPlayerEventListener;
 pub use nusb::DeviceId;
 pub use devices_watch::DeviceMap;
 pub use devices_watch::DevicesPlayerEventApplier;
+pub use service_state::FsctServiceState;

--- a/core/src/service_entry.rs
+++ b/core/src/service_entry.rs
@@ -19,17 +19,17 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use anyhow::anyhow;
 use crate::player::{Player, PlayerState};
-use crate::{devices_watch, player_watch};
+use crate::{devices_watch, player_watch, DevicesWatchHandle};
 use crate::devices_watch::DevicesPlayerEventApplier;
 
 
-pub async fn run_service(player: Player) -> Result<(), anyhow::Error> {
+pub async fn run_service(player: Player) -> Result<DevicesWatchHandle, anyhow::Error> {
     let fsct_devices = Arc::new(Mutex::new(HashMap::new()));
     let player_state = Arc::new(Mutex::new(PlayerState::default()));
 
     let player_event_listener = DevicesPlayerEventApplier::new(fsct_devices.clone());
 
-    devices_watch::run_devices_watch(fsct_devices.clone(), player_state.clone()).await?;
+    let devices_watch_handle = devices_watch::run_devices_watch(fsct_devices.clone(), player_state.clone()).await?;
     player_watch::run_player_watch(player, player_event_listener, player_state).await.map_err(|e| anyhow!(e))?;
-    Ok(())
+    Ok(devices_watch_handle)
 }

--- a/core/src/usb/fsct_usb_interface.rs
+++ b/core/src/usb/fsct_usb_interface.rs
@@ -182,20 +182,4 @@ impl FsctUsbInterface {
             .map_err_to_fsct_device_control_transfer_error()?;
         Ok(())
     }
-
-    pub async fn poll(&self) -> Result<(), FsctDeviceError> {
-        let control_out = ControlOut {
-            control_type: ControlType::Vendor,
-            recipient: Recipient::Interface,
-            request: requests::FsctRequestCode::Poll as u8,
-            value: 0,
-            index: self.interface.interface_number() as u16,
-            data: &[],
-        };
-        self.interface.control_out(control_out).await.into_result()
-            .context("Failed to poll")
-            .map_err_to_fsct_device_control_transfer_error()?;
-
-        Ok(())
-    }
 }

--- a/ports/native/src/windows/service/mod.rs
+++ b/ports/native/src/windows/service/mod.rs
@@ -22,7 +22,6 @@ pub mod install;
 pub mod logger;
 pub mod runtime;
 pub mod standalone;
-pub mod state;
 
 // Re-export commonly used items
 pub use cli::{Cli, Commands, ServiceCommands, LogLevel};

--- a/ports/native/src/windows/service/runtime.rs
+++ b/ports/native/src/windows/service/runtime.rs
@@ -195,7 +195,7 @@ pub fn run_service_main(_arguments: Vec<OsString>) -> anyhow::Result<()> {
                                 windows_service::service::SessionChangeReason::SessionLogoff => {
                                     if service_state.device_watch_handle.is_some() {
                                         info!("This session ({}) is logging off, stopping service tasks", session_id);
-                                        service_state.stop_service();
+                                        service_state.stop_service().await;
                                     } else {
                                         debug!("This session ({}) is logging off, but service is not started, can't \
                                         stop it, ignoring...", session_id)
@@ -206,7 +206,7 @@ pub fn run_service_main(_arguments: Vec<OsString>) -> anyhow::Result<()> {
                                 windows_service::service::SessionChangeReason::RemoteDisconnect => {
                                     if service_state.device_watch_handle.is_some() {
                                         info!("This session ({}) is disconnecting, stopping service tasks", session_id);
-                                        service_state.stop_service();
+                                        service_state.stop_service().await;
                                     } else {
                                         debug!("This session ({}) is disconnecting, but service is not started, can't \
                                         stop it, ignoring...",
@@ -231,7 +231,7 @@ pub fn run_service_main(_arguments: Vec<OsString>) -> anyhow::Result<()> {
 
         // Stop the service tasks
         debug!("Stopping service tasks");
-        service_state.stop_service();
+        service_state.stop_service().await;
 
         info!("Exiting service");
     });

--- a/ports/native/src/windows/service/state.rs
+++ b/ports/native/src/windows/service/state.rs
@@ -49,6 +49,8 @@ impl FsctServiceState {
                 error!("Error shutting down device watch: {}", e);
             }
         }
+        self.player_watch_handle.take().unwrap().abort();
+
         // Clear the handles
         self.player_watch_handle = None;
         self.platform_player = None;


### PR DESCRIPTION
* refactor(usb): remove unused polling logic from FsctUsbInterface and FsctDevice

Eliminated the `poll` method and associated task management in `FsctDevice` and `FsctUsbInterface` as they are no longer required. This simplifies the code and removes redundant task handling.

* refactor(core): WIP enhance device watch task management with shutdown handling

Introduced `DevicesWatchHandle` to manage shutdown logic for device watch tasks. Updated relevant methods and service logic to support asynchronous shutdown, improving resource cleanup and reliability.

*refactor(windows): add shutdown signal handling for standalone service

Introduced `shutdown_signal` to handle both Ctrl+C and Windows close signals in standalone service mode. This improves shutdown reliability and user experience.

* refactor(core, node): add abort functionality and improve service startup logic

Added `abort` method for `DevicesWatchHandle` and `FsctServiceAbortHandle` to enhance immediate task termination. Updated service startup logic to handle race conditions more reliably by ensuring proper handling of already running services. Improved error handling for device watch shutdown.

* refactor(node): rename and simplify the service handle mechanism

Replaced `FsctServiceAbortHandle` with `FsctServiceHandle` to reflect its broader functionality beyond just aborting. Simplified service startup and shutdown logic by consolidating handle operations and improving code clarity.

* refactor(core): enhance device watch shutdown handling with an oneshot channel

Replaced mutex-based shutdown signaling with a `oneshot` channel in `DevicesWatchHandle`. Improved shutdown logic by leveraging `tokio::select!` for better task cleanup and handling device events efficiently.

* refactor(core, node): unify FsctServiceState across platforms

Moved `FsctServiceState` to `core` for shared usage across `node` and `windows` platforms. Refactored service logic to use the new centralized implementation, simplifying code and improving maintainability. Adjusted method signatures and removed duplicated functionality to align with the updated structure.

Refs: FSCT-33