### PR TITLE
Introduce reusable workflows for CI builds and publication

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+*.local.json
+worktrees

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+    tags: ['v*']
+    paths-ignore:
+      - '.cross/**'
+      - 'Cross.toml'
+      - '.github/workflows/build-cross-images.yml'
+  pull_request:
+    branches: [main, develop, 'release/**', 'hotfix/**']
+    paths-ignore:
+      - '.cross/**'
+      - 'Cross.toml'
+      - '.github/workflows/build-cross-images.yml'
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: 'Publish dist-tag (none = build only, dev/next/latest = publish to npm).'
+        type: choice
+        options: [none, dev, next, latest]
+        default: 'none'
+      create_release:
+        description: 'Force-create a GitHub Release for this build.'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+jobs:
+  version:
+    uses: ./.github/workflows/version.yml
+    with:
+      publish_target_override: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_target || '' }}
+      create_release_override: ${{ github.event_name == 'workflow_dispatch' && inputs.create_release || false }}
+
+  build-linux:
+    needs: version
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      cargo_version: ${{ needs.version.outputs.cargo_version }}
+
+  build-windows:
+    needs: version
+    uses: ./.github/workflows/windows-build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      cargo_version: ${{ needs.version.outputs.cargo_version }}
+      msi_version: ${{ needs.version.outputs.msi_version }}
+    secrets: inherit
+
+  build-macos:
+    needs: version
+    uses: ./.github/workflows/macos-build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      cargo_version: ${{ needs.version.outputs.cargo_version }}
+      is_release_or_prerelease: ${{ needs.version.outputs.is_release == 'true' || needs.version.outputs.is_prerelease == 'true' }}
+    secrets: inherit
+
+  build-node:
+    needs: version
+    uses: ./.github/workflows/node-client-build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      cargo_version: ${{ needs.version.outputs.cargo_version }}
+
+  publish:
+    needs: [version, build-linux, build-windows, build-macos, build-node]
+    if: ${{ needs.version.outputs.should_publish_npm == 'true' || needs.version.outputs.should_create_release == 'true' }}
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      npm_tag: ${{ needs.version.outputs.npm_tag }}
+      is_release: ${{ needs.version.outputs.is_release == 'true' }}
+      should_publish_npm: ${{ needs.version.outputs.should_publish_npm == 'true' }}
+      should_create_release: ${{ needs.version.outputs.should_create_release == 'true' }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,12 @@ jobs:
     needs: version
     uses: ./.github/workflows/linux-build.yml
     with:
-      version: ${{ needs.version.outputs.version }}
       cargo_version: ${{ needs.version.outputs.cargo_version }}
 
   build-windows:
     needs: version
     uses: ./.github/workflows/windows-build.yml
     with:
-      version: ${{ needs.version.outputs.version }}
       cargo_version: ${{ needs.version.outputs.cargo_version }}
       msi_version: ${{ needs.version.outputs.msi_version }}
     secrets: inherit
@@ -57,16 +55,14 @@ jobs:
     needs: version
     uses: ./.github/workflows/macos-build.yml
     with:
-      version: ${{ needs.version.outputs.version }}
       cargo_version: ${{ needs.version.outputs.cargo_version }}
-      is_release_or_prerelease: ${{ needs.version.outputs.is_release == 'true' || needs.version.outputs.is_prerelease == 'true' }}
+      should_notarize: ${{ needs.version.outputs.should_notarize == 'true' }}
     secrets: inherit
 
   build-node:
     needs: version
     uses: ./.github/workflows/node-client-build.yml
     with:
-      version: ${{ needs.version.outputs.version }}
       cargo_version: ${{ needs.version.outputs.cargo_version }}
 
   publish:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -3,10 +3,6 @@ name: Build Debian packages
 on:
   workflow_call:
     inputs:
-      version:
-        description: 'Full SemVer (e.g. 0.2.14-alpha.5).'
-        type: string
-        required: true
       cargo_version:
         description: 'Version string passed to cargo set-version (usually identical to version).'
         type: string
@@ -61,6 +57,8 @@ jobs:
             /root/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ matrix.rust_target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.rust_target }}-
 
       - name: Package .deb (full script)
         env:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,26 +1,16 @@
 name: Build Debian packages
 
 on:
-  push:
-    branches: [ '*' ]
-    tags: [ 'v*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - 'build-cross-images.yml'
-  pull_request:
-    branches: [ develop, main, 'release/**', 'hotfix/**' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - 'build-cross-images.yml'
-  release:
-    types: [ created ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full SemVer (e.g. 0.2.14-alpha.5).'
+        type: string
+        required: true
+      cargo_version:
+        description: 'Version string passed to cargo set-version (usually identical to version).'
+        type: string
+        required: true
 
 concurrency:
   group: build-deb-${{ github.ref }}
@@ -58,6 +48,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,26 +1,21 @@
 name: macOS Build
 
 on:
-  push:
-    branches: [ '*' ]
-    tags: [ 'v*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  pull_request:
-    branches: [ main, develop, 'release/*', 'hotfix/*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  release:
-    types: [ created ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full SemVer.'
+        type: string
+        required: true
+      cargo_version:
+        description: 'Version string passed to cargo set-version.'
+        type: string
+        required: true
+      is_release_or_prerelease:
+        description: 'true when this build maps to a release/prerelease tag — enables notarization.'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build-macos:
@@ -37,6 +32,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -68,77 +67,64 @@ jobs:
       - name: Setup certificates
         if: ${{ env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
         run: |
-          # Create a temporary keychain
           security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" build.keychain
           security set-keychain-settings -t 3600 -u build.keychain
-          
-          # Import the certificate (contains both application and installer certificates)
+
           echo "${{ env.APPLE_CERTIFICATE_BASE64 }}" | base64 --decode > certificate.p12
           security import certificate.p12 -k build.keychain -P "${{ env.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/pkgbuild -T /usr/bin/productbuild
-          
-          # Set key partition list
+
           security set-key-partition-list -S apple-tool:,apple: -s -k "${{ env.KEYCHAIN_PASSWORD }}" build.keychain
-          
-          # Verify the keychain is properly set up
+
           echo "Verifying keychain setup..."
           security list-keychains
           security find-identity -v build.keychain
-          
-          # Clean up
+
           rm certificate.p12
 
       - name: Setup notarization profile
         if: ${{ env.APPLE_ID != '' && env.APPLE_TEAM_ID != '' && env.APPLE_APP_PASSWORD != '' }}
         run: |
-          # Create notarization profile
           xcrun notarytool store-credentials "${{ env.APPLE_NOTARY_PROFILE }}" \
             --apple-id "${{ env.APPLE_ID }}" \
             --team-id "${{ env.APPLE_TEAM_ID }}" \
             --password "${{ env.APPLE_APP_PASSWORD }}"
 
-      # Set a flag to determine if we should notarize
+      # Notarize on release/prerelease tags and on integration branches (develop, release/*, hotfix/*).
       - name: Set notarization flag
         id: set_notarize
         run: |
-          SHOULD_NOTARIZE=true
-          
-          # Check if we're on a branch that should be notarized
-          if [[ "${{ github.ref }}" == "refs/heads/develop" || 
-                "${{ github.ref }}" == "refs/heads/main" || 
-                "${{ github.ref }}" =~ ^refs/heads/release/.* || 
-                "${{ github.ref }}" =~ ^refs/heads/hotfix/.* || 
-                "${{ github.ref }}" =~ ^refs/tags/v.* ]]; then
+          SHOULD_NOTARIZE=false
+          if [[ "${{ inputs.is_release_or_prerelease }}" == "true" ]]; then
+            SHOULD_NOTARIZE=true
+          elif [[ "${{ github.ref }}" == "refs/heads/develop" || \
+                  "${{ github.ref }}" == "refs/heads/main" || \
+                  "${{ github.ref }}" =~ ^refs/heads/release/.* || \
+                  "${{ github.ref }}" =~ ^refs/heads/hotfix/.* ]]; then
             SHOULD_NOTARIZE=true
           fi
-          
           echo "should_notarize=$SHOULD_NOTARIZE" >> $GITHUB_OUTPUT
           echo "Branch/tag: ${{ github.ref }}"
           echo "Should notarize: $SHOULD_NOTARIZE"
 
-      # Build with signing and notarization for specific branches/tags
       - name: Build macOS Package (signed and notarized)
         if: ${{ steps.set_notarize.outputs.should_notarize == 'true' && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != ''}}
         run: |
           chmod +x ./script/macos_service_package_builder.sh
-          # Pass the keychain password to the script
           export KEYCHAIN_PASSWORD="${{ env.KEYCHAIN_PASSWORD }}"
           ./script/macos_service_package_builder.sh
           echo "Package is signed and notarized"
 
-      # Build with signing but without notarization for other branches
       - name: Build macOS Package (signed only)
         if: ${{ steps.set_notarize.outputs.should_notarize != 'true' && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
         run: |
           chmod +x ./script/macos_service_package_builder.sh
-          # Pass the keychain password to the script
           export KEYCHAIN_PASSWORD="${{ env.KEYCHAIN_PASSWORD }}"
           ./script/macos_service_package_builder.sh \
             --skip-notarization
           echo "Package is signed but not notarized"
 
-      # Build without signing when certificates are not available
       - name: Build macOS Package (unsigned)
         if: ${{ env.APPLE_CERTIFICATE_BASE64 == '' || env.APPLE_CERTIFICATE_PASSWORD == '' }}
         run: |
@@ -149,15 +135,6 @@ jobs:
       - name: Upload Package Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fsct-driver-macos-${{ github.run_number }}
+          name: fsct-driver-macos
           path: target/package/fsct-driver-*.pkg
           retention-days: 30
-
-      - name: Upload to Release
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target/package/fsct-driver-*.pkg
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -3,16 +3,12 @@ name: macOS Build
 on:
   workflow_call:
     inputs:
-      version:
-        description: 'Full SemVer.'
-        type: string
-        required: true
       cargo_version:
         description: 'Version string passed to cargo set-version.'
         type: string
         required: true
-      is_release_or_prerelease:
-        description: 'true when this build maps to a release/prerelease tag — enables notarization.'
+      should_notarize:
+        description: 'true when macOS artifacts should be notarized.'
         type: boolean
         required: false
         default: false
@@ -33,15 +29,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Inject computed version
-        shell: bash
-        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           targets: x86_64-apple-darwin, aarch64-apple-darwin
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -91,25 +87,13 @@ jobs:
             --team-id "${{ env.APPLE_TEAM_ID }}" \
             --password "${{ env.APPLE_APP_PASSWORD }}"
 
-      # Notarize on release/prerelease tags and on integration branches (develop, release/*, hotfix/*).
-      - name: Set notarization flag
-        id: set_notarize
+      - name: Report notarization policy
         run: |
-          SHOULD_NOTARIZE=false
-          if [[ "${{ inputs.is_release_or_prerelease }}" == "true" ]]; then
-            SHOULD_NOTARIZE=true
-          elif [[ "${{ github.ref }}" == "refs/heads/develop" || \
-                  "${{ github.ref }}" == "refs/heads/main" || \
-                  "${{ github.ref }}" =~ ^refs/heads/release/.* || \
-                  "${{ github.ref }}" =~ ^refs/heads/hotfix/.* ]]; then
-            SHOULD_NOTARIZE=true
-          fi
-          echo "should_notarize=$SHOULD_NOTARIZE" >> $GITHUB_OUTPUT
           echo "Branch/tag: ${{ github.ref }}"
-          echo "Should notarize: $SHOULD_NOTARIZE"
+          echo "Should notarize: ${{ inputs.should_notarize }}"
 
       - name: Build macOS Package (signed and notarized)
-        if: ${{ steps.set_notarize.outputs.should_notarize == 'true' && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != ''}}
+        if: ${{ inputs.should_notarize && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
         run: |
           chmod +x ./script/macos_service_package_builder.sh
           export KEYCHAIN_PASSWORD="${{ env.KEYCHAIN_PASSWORD }}"
@@ -117,7 +101,7 @@ jobs:
           echo "Package is signed and notarized"
 
       - name: Build macOS Package (signed only)
-        if: ${{ steps.set_notarize.outputs.should_notarize != 'true' && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
+        if: ${{ ! inputs.should_notarize && env.APPLE_CERTIFICATE_BASE64 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' }}
         run: |
           chmod +x ./script/macos_service_package_builder.sh
           export KEYCHAIN_PASSWORD="${{ env.KEYCHAIN_PASSWORD }}"

--- a/.github/workflows/node-client-build.yml
+++ b/.github/workflows/node-client-build.yml
@@ -1,22 +1,16 @@
 name: Node Client Build
 
 on:
-  push:
-    branches: [ '**' ]
-    tags: [ 'v*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  pull_request:
-    branches: [ main, develop, 'release/*', 'hotfix/*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  release:
-    types: [ created ]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full SemVer for the npm package.'
+        type: string
+        required: true
+      cargo_version:
+        description: 'Version string passed to cargo set-version (for the ipc_test_server binary).'
+        type: string
+        required: true
 
 concurrency:
   group: node-client-build-${{ github.ref }}
@@ -42,6 +36,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: clients/node/package-lock.json
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -89,18 +87,11 @@ jobs:
         working-directory: clients/node
         run: npm pack
 
+      # Tarball is the same on all 3 OSes (pure JS in dist/); upload it once from Linux only.
       - name: Upload npm package artifact
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: fsct-client-node-${{ matrix.os }}-${{ github.run_number }}
+          name: fsct-client-node
           path: clients/node/hemspzoo-fsct-client-*.tgz
           retention-days: 30
-
-      - name: Upload to Release
-        if: (github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')) && matrix.os == 'ubuntu-latest'
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            clients/node/hemspzoo-fsct-client-*.tgz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-client-build.yml
+++ b/.github/workflows/node-client-build.yml
@@ -3,10 +3,6 @@ name: Node Client Build
 on:
   workflow_call:
     inputs:
-      version:
-        description: 'Full SemVer for the npm package.'
-        type: string
-        required: true
       cargo_version:
         description: 'Version string passed to cargo set-version (for the ipc_test_server binary).'
         type: string
@@ -37,14 +33,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: clients/node/package-lock.json
 
-      - name: Inject computed version
-        shell: bash
-        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,9 +103,14 @@ jobs:
             echo "::error::NPM_TOKEN secret is not set in the repository."
             exit 1
           fi
-          TARBALL=$(ls dist/hemspzoo-fsct-client-*.tgz | head -n1)
+          TARBALL=$(find dist -maxdepth 1 -name 'hemspzoo-fsct-client-*.tgz' -print -quit)
           if [[ -z "$TARBALL" ]]; then
             echo "::error::No npm tarball found in dist/."
+            exit 1
+          fi
+          TARBALL_VERSION=$(tar -xzOf "$TARBALL" package/package.json | node -e 'console.log(JSON.parse(require("fs").readFileSync(0)).version)')
+          if [[ "$TARBALL_VERSION" != "${{ inputs.version }}" ]]; then
+            echo "::error::Tarball version ($TARBALL_VERSION) != expected (${{ inputs.version }})"
             exit 1
           fi
           echo "Publishing $TARBALL with --tag ${{ inputs.npm_tag }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,112 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full SemVer.'
+        type: string
+        required: true
+      npm_tag:
+        description: 'npm dist-tag (latest / next / dev / skip).'
+        type: string
+        required: true
+      is_release:
+        description: 'true when this is a final release (vX.Y.Z tag).'
+        type: boolean
+        required: true
+      should_publish_npm:
+        type: boolean
+        required: true
+      should_create_release:
+        type: boolean
+        required: true
+    secrets:
+      NPM_TOKEN:
+        required: false
+
+jobs:
+  github-release:
+    name: GitHub Release
+    if: ${{ inputs.should_create_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded artifacts
+        run: find artifacts -type f | sort
+
+      - name: Resolve tag name
+        id: tag
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=v${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          prerelease: ${{ !inputs.is_release }}
+          generate_release_notes: true
+          files: |
+            artifacts/deb-amd64/*.deb
+            artifacts/deb-i386/*.deb
+            artifacts/deb-armhf/*.deb
+            artifacts/deb-arm64/*.deb
+            artifacts/fsct-driver-installer-windows/*.exe
+            artifacts/fsct-driver-macos/*.pkg
+            artifacts/fsct-client-node/*.tgz
+
+  npm-publish:
+    name: npm publish
+    needs: github-release
+    # Runs when npm publish is requested, regardless of whether GH Release ran (it might be
+    # skipped on workflow_dispatch with only publish_target set). Refuses to run if GH Release
+    # ran and failed — that avoids publishing to npm without a matching GH Release.
+    if: ${{ always() && inputs.should_publish_npm && (needs.github-release.result == 'success' || needs.github-release.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Download node tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: fsct-client-node
+          path: dist
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::error::NPM_TOKEN secret is not set in the repository."
+            exit 1
+          fi
+          TARBALL=$(ls dist/hemspzoo-fsct-client-*.tgz | head -n1)
+          if [[ -z "$TARBALL" ]]; then
+            echo "::error::No npm tarball found in dist/."
+            exit 1
+          fi
+          echo "Publishing $TARBALL with --tag ${{ inputs.npm_tag }}"
+          npm publish "$TARBALL" --access public --tag "${{ inputs.npm_tag }}"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,154 @@
+name: Compute Version
+
+on:
+  workflow_call:
+    inputs:
+      publish_target_override:
+        description: 'Override publish target: none / dev / next / latest. Empty = auto from ref.'
+        type: string
+        required: false
+        default: ''
+      create_release_override:
+        description: 'Force create a GitHub Release. Only effective via workflow_dispatch.'
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      version:
+        description: 'Full SemVer (e.g. 0.2.14-alpha.5, 0.2.14-rc.1, 0.2.14).'
+        value: ${{ jobs.compute.outputs.version }}
+      cargo_version:
+        description: 'Version string for cargo set-version (same as version).'
+        value: ${{ jobs.compute.outputs.cargo_version }}
+      msi_version:
+        description: '4-part numeric version for Windows MSI ProductVersion (X.Y.Z.B).'
+        value: ${{ jobs.compute.outputs.msi_version }}
+      npm_tag:
+        description: 'npm dist-tag: latest / next / dev / skip.'
+        value: ${{ jobs.compute.outputs.npm_tag }}
+      is_release:
+        description: 'true when ref is a final release tag (vX.Y.Z).'
+        value: ${{ jobs.compute.outputs.is_release }}
+      is_prerelease:
+        description: 'true when ref is an rc tag (vX.Y.Z-rc.N).'
+        value: ${{ jobs.compute.outputs.is_prerelease }}
+      should_publish_npm:
+        description: 'true when this build should publish to npm.'
+        value: ${{ jobs.compute.outputs.should_publish_npm }}
+      should_create_release:
+        description: 'true when this build should create a GitHub Release.'
+        value: ${{ jobs.compute.outputs.should_create_release }}
+
+jobs:
+  compute:
+    name: GitVersion
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.final.outputs.version }}
+      cargo_version: ${{ steps.final.outputs.cargo_version }}
+      msi_version: ${{ steps.final.outputs.msi_version }}
+      npm_tag: ${{ steps.final.outputs.npm_tag }}
+      is_release: ${{ steps.final.outputs.is_release }}
+      is_prerelease: ${{ steps.final.outputs.is_prerelease }}
+      should_publish_npm: ${{ steps.final.outputs.should_publish_npm }}
+      should_create_release: ${{ steps.final.outputs.should_create_release }}
+    steps:
+      - name: Checkout (full history for GitVersion)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3
+        with:
+          versionSpec: '6.x'
+
+      - name: Run GitVersion
+        id: gv
+        uses: gittools/actions/gitversion/execute@v3
+        with:
+          useConfigFile: true
+          configFilePath: GitVersion.yml
+
+      - name: Compute final outputs
+        id: final
+        shell: bash
+        env:
+          GITVERSION_SEMVER: ${{ steps.gv.outputs.semVer }}
+          GH_REF: ${{ github.ref }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUBLISH_TARGET_OVERRIDE: ${{ inputs.publish_target_override }}
+          CREATE_RELEASE_OVERRIDE: ${{ inputs.create_release_override }}
+        run: |
+          set -euo pipefail
+          VERSION="$GITVERSION_SEMVER"
+
+          # PR fallback: patch the version if GitVersion's {Number} placeholder did not expand.
+          if [[ "$GH_EVENT_NAME" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
+            if [[ "$VERSION" != *"-pr.${PR_NUMBER}."* ]]; then
+              echo "::warning::GitVersion did not expand {Number} ('$VERSION'); patching PR version."
+              BASE="${VERSION%%-*}"
+              COMMITS="${VERSION##*.}"
+              VERSION="${BASE}-pr.${PR_NUMBER}.${COMMITS}"
+            fi
+          fi
+
+          # Detect tag kind from the ref.
+          IS_RELEASE=false
+          IS_PRERELEASE=false
+          NPM_TAG=skip
+          if [[ "$GH_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IS_RELEASE=true
+            NPM_TAG=latest
+          elif [[ "$GH_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            IS_PRERELEASE=true
+            NPM_TAG=next
+          fi
+
+          SHOULD_PUBLISH_NPM=false
+          SHOULD_CREATE_RELEASE=false
+          if [[ "$IS_RELEASE" == "true" || "$IS_PRERELEASE" == "true" ]]; then
+            SHOULD_PUBLISH_NPM=true
+            SHOULD_CREATE_RELEASE=true
+          fi
+
+          # workflow_dispatch overrides.
+          if [[ -n "$PUBLISH_TARGET_OVERRIDE" && "$PUBLISH_TARGET_OVERRIDE" != "none" ]]; then
+            NPM_TAG="$PUBLISH_TARGET_OVERRIDE"
+            SHOULD_PUBLISH_NPM=true
+          fi
+          if [[ "$CREATE_RELEASE_OVERRIDE" == "true" ]]; then
+            SHOULD_CREATE_RELEASE=true
+          fi
+
+          # MSI version: X.Y.Z.B (Windows MSI cannot encode SemVer prerelease).
+          BASE_NUM="${VERSION%%-*}"
+          MSI_VERSION="${BASE_NUM}.${GH_RUN_NUMBER}"
+
+          {
+            echo "version=$VERSION"
+            echo "cargo_version=$VERSION"
+            echo "msi_version=$MSI_VERSION"
+            echo "npm_tag=$NPM_TAG"
+            echo "is_release=$IS_RELEASE"
+            echo "is_prerelease=$IS_PRERELEASE"
+            echo "should_publish_npm=$SHOULD_PUBLISH_NPM"
+            echo "should_create_release=$SHOULD_CREATE_RELEASE"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Computed version"
+            echo ""
+            echo "| Output | Value |"
+            echo "|--------|-------|"
+            echo "| version | \`$VERSION\` |"
+            echo "| cargo_version | \`$VERSION\` |"
+            echo "| msi_version | \`$MSI_VERSION\` |"
+            echo "| npm_tag | \`$NPM_TAG\` |"
+            echo "| is_release | \`$IS_RELEASE\` |"
+            echo "| is_prerelease | \`$IS_PRERELEASE\` |"
+            echo "| should_publish_npm | \`$SHOULD_PUBLISH_NPM\` |"
+            echo "| should_create_release | \`$SHOULD_CREATE_RELEASE\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -38,6 +38,9 @@ on:
       should_create_release:
         description: 'true when this build should create a GitHub Release.'
         value: ${{ jobs.compute.outputs.should_create_release }}
+      should_notarize:
+        description: 'true when macOS artifacts should be notarized.'
+        value: ${{ jobs.compute.outputs.should_notarize }}
 
 jobs:
   compute:
@@ -52,6 +55,7 @@ jobs:
       is_prerelease: ${{ steps.final.outputs.is_prerelease }}
       should_publish_npm: ${{ steps.final.outputs.should_publish_npm }}
       should_create_release: ${{ steps.final.outputs.should_create_release }}
+      should_notarize: ${{ steps.final.outputs.should_notarize }}
     steps:
       - name: Checkout (full history for GitVersion)
         uses: actions/checkout@v4
@@ -88,6 +92,10 @@ jobs:
           # PR fallback: patch the version if GitVersion's {Number} placeholder did not expand.
           if [[ "$GH_EVENT_NAME" == "pull_request" && -n "${PR_NUMBER:-}" ]]; then
             if [[ "$VERSION" != *"-pr.${PR_NUMBER}."* ]]; then
+              if [[ "$VERSION" != *-* ]]; then
+                echo "::error::Unexpected GitVersion output for PR: '$VERSION'"
+                exit 1
+              fi
               echo "::warning::GitVersion did not expand {Number} ('$VERSION'); patching PR version."
               BASE="${VERSION%%-*}"
               COMMITS="${VERSION##*.}"
@@ -114,8 +122,22 @@ jobs:
             SHOULD_CREATE_RELEASE=true
           fi
 
+          SHOULD_NOTARIZE=false
+          if [[ "$IS_RELEASE" == "true" || "$IS_PRERELEASE" == "true" ]]; then
+            SHOULD_NOTARIZE=true
+          elif [[ "$GH_REF" == "refs/heads/develop" || \
+                  "$GH_REF" == "refs/heads/main" || \
+                  "$GH_REF" =~ ^refs/heads/release/.* || \
+                  "$GH_REF" =~ ^refs/heads/hotfix/.* ]]; then
+            SHOULD_NOTARIZE=true
+          fi
+
           # workflow_dispatch overrides.
           if [[ -n "$PUBLISH_TARGET_OVERRIDE" && "$PUBLISH_TARGET_OVERRIDE" != "none" ]]; then
+            if [[ "$PUBLISH_TARGET_OVERRIDE" == "latest" && "$IS_RELEASE" != "true" ]]; then
+              echo "::error::publish_target=latest is only allowed on vX.Y.Z tag refs"
+              exit 1
+            fi
             NPM_TAG="$PUBLISH_TARGET_OVERRIDE"
             SHOULD_PUBLISH_NPM=true
           fi
@@ -136,6 +158,7 @@ jobs:
             echo "is_prerelease=$IS_PRERELEASE"
             echo "should_publish_npm=$SHOULD_PUBLISH_NPM"
             echo "should_create_release=$SHOULD_CREATE_RELEASE"
+            echo "should_notarize=$SHOULD_NOTARIZE"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -151,4 +174,5 @@ jobs:
             echo "| is_prerelease | \`$IS_PRERELEASE\` |"
             echo "| should_publish_npm | \`$SHOULD_PUBLISH_NPM\` |"
             echo "| should_create_release | \`$SHOULD_CREATE_RELEASE\` |"
+            echo "| should_notarize | \`$SHOULD_NOTARIZE\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,26 +1,20 @@
 name: Windows Build
 
 on:
-  push:
-    branches: [ '*' ]
-    tags: [ 'v*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  pull_request:
-    branches: [ main, develop, 'release/*', 'hotfix/*' ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  release:
-    types: [ created ]
-    paths-ignore:
-      - '.cross/**'
-      - 'Cross.toml'
-      - '.github/workflows/build-cross-images.yml'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full SemVer (e.g. 0.2.14-rc.1).'
+        type: string
+        required: true
+      cargo_version:
+        description: 'Version string passed to cargo set-version.'
+        type: string
+        required: true
+      msi_version:
+        description: '4-part numeric version for WiX ProductVersion (X.Y.Z.B).'
+        type: string
+        required: true
 
 jobs:
   build-windows:
@@ -35,6 +29,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -79,27 +77,18 @@ jobs:
       - name: Build Windows Installer (with Azure Key Vault signing)
         if: ${{ env.AZURE_KEY_VAULT_URL != '' && env.AZURE_CERTIFICATE_NAME != '' && env.AZURE_TENANT_ID != '' && env.AZURE_CLIENT_ID != '' && env.AZURE_CLIENT_SECRET != '' }}
         run: |
-          .\script\build_windows_installer.ps1 -UseAzureKeyVault -AzureKeyVaultUrl "${{ env.AZURE_KEY_VAULT_URL }}" -AzureCertificateName "${{ env.AZURE_CERTIFICATE_NAME }}" -AzureTenantId "${{ env.AZURE_TENANT_ID }}" -AzureClientId "${{ env.AZURE_CLIENT_ID }}" -AzureClientSecret "${{ env.AZURE_CLIENT_SECRET }}" -BuildNumber ${{ github.run_number }}
+          .\script\build_windows_installer.ps1 -UseAzureKeyVault -AzureKeyVaultUrl "${{ env.AZURE_KEY_VAULT_URL }}" -AzureCertificateName "${{ env.AZURE_CERTIFICATE_NAME }}" -AzureTenantId "${{ env.AZURE_TENANT_ID }}" -AzureClientId "${{ env.AZURE_CLIENT_ID }}" -AzureClientSecret "${{ env.AZURE_CLIENT_SECRET }}" -MsiVersion "${{ inputs.msi_version }}"
         shell: powershell
 
       - name: Build Windows Installer (unsigned)
         if: ${{ env.AZURE_KEY_VAULT_URL == '' || env.AZURE_CERTIFICATE_NAME == '' || env.AZURE_TENANT_ID == '' || env.AZURE_CLIENT_ID == '' || env.AZURE_CLIENT_SECRET == '' }}
         run: |
-          .\script\build_windows_installer.ps1 -NoSign -BuildNumber ${{ github.run_number }}
+          .\script\build_windows_installer.ps1 -NoSign -MsiVersion "${{ inputs.msi_version }}"
         shell: powershell
 
       - name: Upload EXE Bundle Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fsct-driver-installer-exe-${{ github.run_number }}
+          name: fsct-driver-installer-windows
           path: target\wix_build\FSCTDriverInstaller.exe
           retention-days: 30
-
-      - name: Upload to Release
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target\wix_build\FSCTDriverInstaller.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,10 +3,6 @@ name: Windows Build
 on:
   workflow_call:
     inputs:
-      version:
-        description: 'Full SemVer (e.g. 0.2.14-rc.1).'
-        type: string
-        required: true
       cargo_version:
         description: 'Version string passed to cargo set-version.'
         type: string
@@ -30,14 +26,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Inject computed version
-        shell: bash
-        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+
+      - name: Inject computed version
+        shell: bash
+        run: bash script/inject_version.sh "${{ inputs.cargo_version }}"
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,37 @@ Platform installers consume assets from `packages/` and are built by scripts in 
 - `script/build_windows_installer.ps1` → MSI via WiX v6 (`packages/windows/`)
 - `script/build_linux_deb.sh` → Debian package via fpm (`packages/linux/`)
 - `script/macos_service_package_builder.sh` → notarized pkg (`packages/macos/`)
+- `script/inject_version.sh` → writes the CI-computed version into `Cargo.toml` and `clients/node/package.json` before each build.
 
 Cross-compilation Docker files are in `.cross/` and are used automatically by `cross`.
+
+## Versioning
+
+The version in `Cargo.toml` (`[workspace.package].version`) and `clients/node/package.json` is **always `0.0.0-dev`** in the repository. It is a placeholder; the real version is computed by [GitVersion](https://gitversion.net) in CI and injected by `script/inject_version.sh` before every build. Never commit a real version — `release/*` branches do not "own" the version string. Cutting a release means tagging a commit; nothing in the working tree changes.
+
+### Branch → version
+
+| Ref | Computed version | npm dist-tag | GitHub Release |
+|---|---|---|---|
+| tag `vX.Y.Z` | `X.Y.Z` | `latest` | Release |
+| tag `vX.Y.Z-rc.N` | `X.Y.Z-rc.N` | `next` | Pre-Release |
+| `release/X.Y.Z` push | `X.Y.Z-beta.<N>` | — | — (artifacts only) |
+| `hotfix/X.Y.Z` push | `X.Y.Z-beta.<N>` | — | — (artifacts only) |
+| `develop` push | `X.Y.(Z+1)-alpha.<N>` | — | — (artifacts only) |
+| `feature/<slug>` push | `X.Y.(Z+1)-alpha-<slug>.<N>` | — | — (artifacts only) |
+| pull request | `X.Y.(Z+1)-pr.<PR>.<N>` | — | — (artifacts only) |
+| `workflow_dispatch` | as above for the source branch | per `publish_target` input | per `create_release` input |
+
+`<N>` is commits since the version source. `<PR>` is the pull-request number. Configuration lives in `GitVersion.yml`.
+
+### CI structure
+
+- `.github/workflows/ci.yml` — top-level orchestrator (the only file with `push`/`pull_request`/`workflow_dispatch` triggers).
+- `.github/workflows/version.yml` — runs GitVersion, exposes outputs (`version`, `cargo_version`, `msi_version`, `npm_tag`, `is_release`, `is_prerelease`, `should_publish_npm`, `should_create_release`).
+- `.github/workflows/{linux,windows,macos,node-client}-build.yml` — reusable (`on: workflow_call` only). Each one runs `script/inject_version.sh` first.
+- `.github/workflows/publish.yml` — reusable. Creates the GitHub Release and runs `npm publish` from the same artifacts the build jobs produced. Requires `NPM_TOKEN` secret.
+
+Manual publish: trigger `ci.yml` via "Run workflow" with `publish_target` (`dev` / `next` / `latest`) and/or `create_release` set.
 
 ## Key Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fsct-client"
-version = "0.2.13"
+version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "fsct-core"
-version = "0.2.13"
+version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "fsct-driver"
-version = "0.2.13"
+version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "3"
 members = ["clients/rust", "core", "driver"]
 
 [workspace.package]
-version = "0.2.13"
+# Placeholder. Real version is injected by CI from GitVersion (see GitVersion.yml).
+version = "0.0.0-dev"
 authors = ["Paweł Gorgoń", "HEM Sp. z o.o."]
 description = "Host implementation of Ferrum Streaming Control Technology™ (FSCT). Additional licensing terms apply as described in LICENSE-FSCT.md."
 license = "Apache-2.0"

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -13,8 +13,6 @@
 
 workflow: GitFlow/v1
 
-next-version: 0.2.14
-
 tag-prefix: '[vV]?'
 
 branches:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,38 @@
+# GitVersion configuration for FSCT host (GitFlow).
+#
+# Branch -> version scheme (see CLAUDE.md for rationale):
+#   tag vX.Y.Z         -> X.Y.Z                    (final release; npm latest; GH Release)
+#   tag vX.Y.Z-rc.N    -> X.Y.Z-rc.N               (release candidate; npm next; GH Pre-Release)
+#   release/X.Y.Z      -> X.Y.Z-beta.<N>           (per-commit beta; artifacts only)
+#   hotfix/X.Y.Z       -> X.Y.Z-beta.<N>           (per-commit beta; artifacts only)
+#   develop            -> X.Y.(Z+1)-alpha.<N>      (per-commit alpha; artifacts only)
+#   feature/<slug>     -> X.Y.(Z+1)-alpha-<slug>.<N>
+#   pull-request       -> X.Y.(Z+1)-pr.<PR>.<N>    (PR number from GH ref)
+#
+# Tag prefix accepted: v or V (e.g. v0.2.13).
+
+workflow: GitFlow/v1
+
+next-version: 0.2.14
+
+tag-prefix: '[vV]?'
+
+branches:
+  main:
+    label: ''
+    increment: None
+  develop:
+    label: alpha
+    increment: Patch
+  release:
+    label: beta
+    increment: None
+  hotfix:
+    label: beta
+    increment: Patch
+  feature:
+    label: alpha-{BranchName}
+    increment: Inherit
+  pull-request:
+    label: pr.{Number}
+    increment: Inherit

--- a/clients/node/package.json
+++ b/clients/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hemspzoo/fsct-client",
-  "version": "0.2.13",
+  "version": "0.0.0-dev",
   "description": "Node.js IPC client for the FSCT driver",
   "author": "HEM Sp. z o.o.",
   "license": "Apache-2.0",
@@ -27,6 +27,9 @@
     "LICENSE-FSCT.md",
     "NOTICE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",

--- a/script/build_windows_installer.ps1
+++ b/script/build_windows_installer.ps1
@@ -24,6 +24,7 @@
 #
 param(
     [Parameter()][int]$BuildNumber = 0,
+    [Parameter()][string]$MsiVersion = "",
     [switch]$NoSign,
     [switch]$NoDwnld,
     [switch]$NoLicense,
@@ -342,8 +343,17 @@ try
 
     Write-Host "[INFO] Package version: $packageVersion"
 
+    # If -MsiVersion is provided (e.g. by CI from GitVersion), it overrides the cargo-derived
+    # installer version. WiX ProductVersion must be X.Y.Z.B numeric and cannot encode SemVer
+    # prerelease segments like "-beta.5" or "-rc.1", so CI computes a clean numeric form.
+    if (-not [string]::IsNullOrEmpty($MsiVersion))
+    {
+        $installerVersion = $MsiVersion
+        Write-Host "[INFO] Installer version (from -MsiVersion): $installerVersion"
+    }
+
     # Handle BuildNumber = 0 case
-    if ($BuildNumber -eq 0) {
+    if ([string]::IsNullOrEmpty($MsiVersion) -and $BuildNumber -eq 0) {
         $buildNumberFilePath = Join-Path $env:LOCALAPPDATA "FSCT\windows-installer-buildnumber.txt"
         Write-Host "[INFO] BuildNumber is 0, using persistent build number from $buildNumberFilePath"
 
@@ -383,9 +393,11 @@ try
         }
     }
 
-    $installerVersion = "$packageVersion.$BuildNumber"
-
-    Write-Host "[INFO] Installer version: $installerVersion"
+    if ([string]::IsNullOrEmpty($MsiVersion))
+    {
+        $installerVersion = "$packageVersion.$BuildNumber"
+        Write-Host "[INFO] Installer version: $installerVersion"
+    }
 
     # === Signing EXE ===
     if (-not (Sign-File -FilePath "$BUILD_DIR\$BIN_NAME" -Description "EXE"))

--- a/script/inject_version.sh
+++ b/script/inject_version.sh
@@ -34,7 +34,23 @@ ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed 's/[&|\/\\]/\\&/g')
 sed -i.bak -E "s|^version = \"0\\.0\\.0-dev\"$|version = \"$ESCAPED_VERSION\"|" Cargo.toml
 rm -f Cargo.toml.bak
 
-cargo update -p fsct-core -p fsct-driver -p fsct-client --offline
+awk -v version="$VERSION" '
+  /^name = "fsct-(client|core|driver)"$/ {
+    in_workspace_package = 1
+    print
+    next
+  }
+  in_workspace_package && /^version = / {
+    print "version = \"" version "\""
+    in_workspace_package = 0
+    next
+  }
+  /^\[\[package\]\]$/ {
+    in_workspace_package = 0
+  }
+  { print }
+' Cargo.lock > Cargo.lock.tmp
+mv Cargo.lock.tmp Cargo.lock
 
 # package.json — `npm version` is the canonical tool; it also updates package-lock.json.
 # Linux .deb cross-build containers do not have npm — skip there.

--- a/script/inject_version.sh
+++ b/script/inject_version.sh
@@ -30,8 +30,11 @@ if ! grep -qE '^version = "0\.0\.0-dev"$' Cargo.toml; then
   echo "[inject_version] Has the placeholder been changed? Refusing to patch to avoid corruption." >&2
   exit 1
 fi
-sed -i.bak -E 's|^version = "0\.0\.0-dev"$|version = "'"$VERSION"'"|' Cargo.toml
+ESCAPED_VERSION=$(printf '%s' "$VERSION" | sed 's/[&|\/\\]/\\&/g')
+sed -i.bak -E "s|^version = \"0\\.0\\.0-dev\"$|version = \"$ESCAPED_VERSION\"|" Cargo.toml
 rm -f Cargo.toml.bak
+
+cargo update -p fsct-core -p fsct-driver -p fsct-client --offline
 
 # package.json — `npm version` is the canonical tool; it also updates package-lock.json.
 # Linux .deb cross-build containers do not have npm — skip there.

--- a/script/inject_version.sh
+++ b/script/inject_version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Inject a computed version (from CI / GitVersion) into the workspace.
+#
+# - Patches the workspace.package.version line in the root Cargo.toml. Internal crates use
+#   `version.workspace = true`, so a single root-level substitution is enough.
+# - Patches clients/node/package.json via `npm version`.
+#
+# Idempotent only against the `0.0.0-dev` placeholder. CI always starts from a fresh checkout,
+# so this is safe.
+
+set -euo pipefail
+
+VERSION="${1:-${FSCT_VERSION:-}}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>" >&2
+  echo "   or: FSCT_VERSION=<version> $0" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[inject_version] Setting workspace version: $VERSION"
+
+# Cargo.toml — replace the placeholder line. Anchored to start-of-line to avoid touching
+# unrelated `version = ...` lines in [workspace.dependencies].
+if ! grep -qE '^version = "0\.0\.0-dev"$' Cargo.toml; then
+  echo "[inject_version] ERROR: expected placeholder 'version = \"0.0.0-dev\"' not found in Cargo.toml" >&2
+  echo "[inject_version] Has the placeholder been changed? Refusing to patch to avoid corruption." >&2
+  exit 1
+fi
+sed -i.bak -E 's|^version = "0\.0\.0-dev"$|version = "'"$VERSION"'"|' Cargo.toml
+rm -f Cargo.toml.bak
+
+# package.json — `npm version` is the canonical tool; it also updates package-lock.json.
+# Linux .deb cross-build containers do not have npm — skip there.
+if command -v npm >/dev/null 2>&1; then
+  (
+    cd clients/node
+    npm version "$VERSION" --no-git-tag-version --allow-same-version >/dev/null
+  )
+  NODE_VERSION_LINE=$(grep -E '"version":' clients/node/package.json | head -n1)
+else
+  NODE_VERSION_LINE="(npm not available — skipped)"
+fi
+
+echo "[inject_version] Cargo.toml:        $(grep -E '^version = ' Cargo.toml | head -n1)"
+echo "[inject_version] package.json:      $NODE_VERSION_LINE"


### PR DESCRIPTION
This PR introduces reusable GitHub Actions workflows for streamlined CI processes, including:

- Modular workflows for versioning, building, and publishing across platforms (Linux, macOS, Windows, Node.js).
- Centralized trigger management using `workflow_call` to avoid redundancy.
- Automation for version injection and upload of build artifacts.

### Changes

- Added reusable workflows for efficient build and publication pipelines.
- Replaced repetitive triggers with modular workflow configurations.
