### PR TITLE
fix(ci): adjust tarball search path in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
             echo "::error::NPM_TOKEN secret is not set in the repository."
             exit 1
           fi
-          TARBALL=$(find dist -maxdepth 1 -name 'hemspzoo-fsct-client-*.tgz' -print -quit)
+          TARBALL=$(find "$PWD/dist" -maxdepth 1 -name 'hemspzoo-fsct-client-*.tgz' -print -quit)
           if [[ -z "$TARBALL" ]]; then
             echo "::error::No npm tarball found in dist/."
             exit 1


### PR DESCRIPTION
Updated the `find` command in the publish workflow to use an absolute path (`$PWD/dist`) for locating the npm tarball. Resolves issues with inconsistent working directories during runtime.