### PR TITLE
fix(ci): exclude cached .deb files during build

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -56,6 +56,7 @@ jobs:
             /root/.cargo/registry
             /root/.cargo/git
             target
+            !target/deb
           key: ${{ runner.os }}-cargo-${{ matrix.rust_target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.rust_target }}-

--- a/script/build_linux_deb.sh
+++ b/script/build_linux_deb.sh
@@ -81,10 +81,11 @@ if (( ${#missing[@]} > 0 )); then
   echo "Proceeding despite missing deps due to --allow-missing-deps" >&2
 fi
 
-# Clean staging
+# Clean staging and any stale .deb outputs from previous runs (e.g. restored from CI cache)
 rm -rf "${BUILD_ROOT}"
 mkdir -p "${STAGE_DIR}"
 mkdir -p "${OUTPUT_DIR}"
+rm -f "${OUTPUT_DIR}"/*.deb
 
 # Build Rust binaries (unless skipped)
 if [[ "$SKIP_BUILD" == true ]]; then


### PR DESCRIPTION
Updated the Linux build workflow to prevent restoration of cached .deb files in CI. Enhanced the `build_linux_deb.sh` script to clean up stale .deb outputs before building.